### PR TITLE
New rate curves and fix BF rates

### DIFF
--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -52,6 +52,45 @@
 #define BF_EXPO_PITCH 0.40
 #define BF_EXPO_YAW 0.40
 
+// ******************** ACTUAL_RATES ********************
+#define ACTUAL_CENTER_SENS_ROLL 250
+#define ACTUAL_CENTER_SENS_PITCH 250
+#define ACTUAL_CENTER_SENS_YAW 250
+
+#define ACTUAL_MAX_RATE_ROLL 860.0
+#define ACTUAL_MAX_RATE_PITCH 860.0
+#define ACTUAL_MAX_RATE_YAW 860.0
+
+#define ACTUAL_EXPO_ROLL 0.5
+#define ACTUAL_EXPO_PITCH 0.5
+#define ACTUAL_EXPO_YAW 0.5
+
+// ******************** KISS_RATES ********************
+#define KISS_RC_RATE_ROLL 0.70
+#define KISS_RC_RATE_PITCH 0.70
+#define KISS_RC_RATE_YAW 0.70
+
+#define KISS_RATE_ROLL 0.70
+#define KISS_RATE_PITCH 0.70
+#define KISS_RATE_YAW 0.70
+
+#define KISS_CURVE_ROLL 0.40
+#define KISS_CURVE_PITCH 0.40
+#define KISS_CURVE_YAW 0.40
+
+// ******************** RACEFLIGHT_RATES ********************
+#define RACEFLIGHT_RATE_ROLL 400
+#define RACEFLIGHT_RATE_PITCH 400
+#define RACEFLIGHT_RATE_YAW 400
+
+#define RACEFLIGHT_EXPO_ROLL 0.50
+#define RACEFLIGHT_EXPO_PITCH 0.50
+#define RACEFLIGHT_EXPO_YAW 0.50
+
+#define RACEFLIGHT_ACRO_PLUS_ROLL 140.0
+#define RACEFLIGHT_ACRO_PLUS_PITCH 140.0
+#define RACEFLIGHT_ACRO_PLUS_YAW 140.0
+
 // *************max angle for level mode
 #define LEVEL_MAX_ANGLE 65.0f
 
@@ -272,7 +311,7 @@
 //#define MOTOR_BEEPS
 //#define MOTOR_BEEPS_TIMEOUT 1e6
 
-// *************enable inverted flight code ( brushless only ) - WARNING - NEVER TESTED 
+// *************enable inverted flight code ( brushless only ) - WARNING - NEVER TESTED
 //#define INVERTED_ENABLE
 //#define FN_INVERTED AUX_CHANNEL_OFF //for brushless only
 
@@ -300,4 +339,3 @@
 
 // throttle direct to motors for thrust measure
 //#define MOTORS_TO_THROTTLE
-

--- a/src/main/config/defines.h
+++ b/src/main/config/defines.h
@@ -32,7 +32,7 @@ static const float pid_scales[PID_SIZE][PID_SIZE] = {
 #define YAW 2
 
 // this should be precalculated by the compiler when parameters are constant
-//(1 - alpha. filtertime = 1 / filter-cutoff-frequency) as long as filtertime > sampleperiod
+// (1 - alpha. filtertime = 1 / filter-cutoff-frequency) as long as filtertime > sampleperiod
 #define FILTERCALC(sampleperiod, filtertime) (1.0f - (6.0f * (float)sampleperiod) / (3.0f * (float)sampleperiod + (float)filtertime))
 
 #ifdef BETAFLIGHT_RATES

--- a/src/main/config/profile.c
+++ b/src/main/config/profile.c
@@ -75,7 +75,7 @@ const pid_rate_preset_t pid_rate_presets[] = {
             .kp = {127, 127, 148},
             .ki = {77, 77, 77},
             .kd = {101, 101, 13},
-        
+
         },
     },
 
@@ -298,6 +298,57 @@ const profile_t default_profile = {
                 BF_EXPO_YAW,
             },
         },
+        .actual = {
+            .center_sensitivity = {
+                ACTUAL_CENTER_SENS_ROLL,
+                ACTUAL_CENTER_SENS_PITCH,
+                ACTUAL_CENTER_SENSE_YAW,
+            },
+            .max_rate = {
+                ACTUAL_MAX_RATE_ROLL,
+                ACTUAL_MAX_RATE_PITCH,
+                ACTUAL_MAX_RATE_YAW,
+            },
+            .expo = {
+                ACTUAL_EXPO_ROLL,
+                ACTUAL_EXPO_PITCH,
+                ACTUAL_EXPO_YAW,
+            },
+        },
+        .kiss = {
+            .rc_rate = {
+                KISS_RC_RATE_ROLL,
+                KISS_RC_RATE_PITCH,
+                KISS_RC_RATE_YAW,
+            },
+            .rate = {
+                KISS_RATE_ROLL,
+                KISS_RATE_PITCH,
+                KISS_RATE_YAW,
+            },
+            .curve = {
+                KISS_CURVE_ROLL,
+                KISS_CURVE_PITCH,
+                KISS_CURVE_YAW,
+            },
+        },
+        .raceflight = {
+            .rate = {
+                RACEFLIGHT_RATE_ROLL,
+                RACEFLIGHT_RATE_PITCH,
+                RACEFLIGHT_RATE_YAW,
+            },
+            .expo = {
+                RACEFLIGHT_EXPO_ROLL,
+                RACEFLIGHT_EXPO_PITCH,
+                RACEFLIGHT_EXPO_YAW,
+            },
+            .acro_plus = {
+                RACEFLIGHT_ACRO_PLUS_ROLL,
+                RACEFLIGHT_ACRO_PLUS_PITCH,
+                RACEFLIGHT_ACRO_PLUS_YAW,
+            },
+        },
 
         .level_max_angle = LEVEL_MAX_ANGLE,
         .low_rate_mulitplier = LOW_RATES_MULTI,
@@ -516,6 +567,18 @@ CBOR_START_STRUCT_ENCODER(rate_mode_betaflight_t)
 BETAFLIGHT_RATE_MEMBERS
 CBOR_END_STRUCT_ENCODER()
 
+CBOR_START_STRUCT_ENCODER(rate_mode_actual_t)
+ACTUAL_RATE_MEMBERS
+CBOR_END_STRUCT_ENCODER()
+
+CBOR_START_STRUCT_ENCODER(rate_mode_kiss_t)
+KISS_RATE_MEMBERS
+CBOR_END_STRUCT_ENCODER()
+
+CBOR_START_STRUCT_ENCODER(rate_mode_raceflight_t)
+RACEFLIGHT_RATE_MEMBERS
+CBOR_END_STRUCT_ENCODER()
+
 CBOR_START_STRUCT_ENCODER(profile_rate_t)
 RATE_MEMBERS
 CBOR_END_STRUCT_ENCODER()
@@ -638,6 +701,18 @@ CBOR_END_STRUCT_DECODER()
 
 CBOR_START_STRUCT_DECODER(rate_mode_betaflight_t)
 BETAFLIGHT_RATE_MEMBERS
+CBOR_END_STRUCT_DECODER()
+
+CBOR_START_STRUCT_DECODER(rate_mode_actual_t)
+ACTUAL_RATE_MEMBERS
+CBOR_END_STRUCT_DECODER()
+
+CBOR_START_STRUCT_DECODER(rate_mode_kiss_t)
+KISS_RATE_MEMBERS
+CBOR_END_STRUCT_DECODER()
+
+CBOR_START_STRUCT_DECODER(rate_mode_raceflight_t)
+RACEFLIGHT_RATE_MEMBERS
 CBOR_END_STRUCT_DECODER()
 
 CBOR_START_STRUCT_DECODER(profile_rate_t)

--- a/src/main/config/profile.h
+++ b/src/main/config/profile.h
@@ -10,6 +10,9 @@
 typedef enum {
   RATE_MODE_SILVERWARE,
   RATE_MODE_BETAFLIGHT,
+  RATE_MODE_ACTUAL,
+  RATE_MODE_KISS,
+  RATE_MODE_RACEFLIGHT,
 } rate_modes_t;
 
 typedef struct {
@@ -35,9 +38,46 @@ typedef struct {
   MEMBER(expo, vec3_t)
 
 typedef struct {
+  vec3_t center_sensitivity;
+  vec3_t max_rate;
+  vec3_t expo;
+} rate_mode_actual_t;
+
+#define ACTUAL_RATE_MEMBERS           \
+  MEMBER(center_sensitivity, vec3_t)  \
+  MEMBER(max_rate, vec3_t)            \
+  MEMBER(expo, vec3_t)
+
+typedef struct {
+  vec3_t rc_rate;
+  vec3_t rate;
+  vec3_t rc_curve;
+} rate_mode_kiss_t;
+
+#define KISS_RATE_MEMBERS       \
+  MEMBER(rc_rate, vec3_t)       \
+  MEMBER(rate, vec3_t)          \
+  MEMBER(rc_curve, vec3_t)
+
+typedef struct {
+  vec3_t rate;
+  vec3_t expo;
+  vec3_t acro_plus;
+} rate_mode_raceflight_t;
+
+#define RACEFLIGHT_RATE_MEMBERS \
+  MEMBER(rate, vec3_t)          \
+  MEMBER(expo, vec3_t)          \
+  MEMBER(acro_plus, vec3_t)
+
+
+typedef struct {
   rate_modes_t mode;
   rate_mode_silverware_t silverware;
   rate_mode_betaflight_t betaflight;
+  rate_mode_actual_t actual;
+  rate_mode_kiss_t kiss;
+  rate_mode_raceflight_t raceflight;
   float level_max_angle;
   float low_rate_mulitplier;
   float sticks_deadband;
@@ -47,6 +87,9 @@ typedef struct {
   MEMBER(mode, uint8)                        \
   MEMBER(silverware, rate_mode_silverware_t) \
   MEMBER(betaflight, rate_mode_betaflight_t) \
+  MEMBER(actual, rate_mode_actual_t)         \
+  MEMBER(kiss, rate_mode_kiss_t)             \
+  MEMBER(raceflight, rate_mode_raceflight_t) \
   MEMBER(level_max_angle, float)             \
   MEMBER(low_rate_mulitplier, float)         \
   MEMBER(sticks_deadband, float)

--- a/src/main/control.h
+++ b/src/main/control.h
@@ -49,6 +49,7 @@ typedef struct {
 
   vec4_t rx;          // holds the raw or calibrated main four channels, roll, pitch, yaw, throttle
   vec4_t rx_filtered; // same as above, but with constraints(just in case), expo applied smoothing applied and deadband applied
+  vec4_t rx_filtered_no_expo; // same as the above but with no expo applied.
   vec4_t rx_override; // override values, activated by controls_override
 
   stick_calibration_wizard_t stick_calibration_wizard; // current phase of the calibration wizard
@@ -97,6 +98,7 @@ typedef struct {
   MEMBER(vreffilt, float)                   \
   MEMBER(rx, vec4_t)                        \
   MEMBER(rx_filtered, vec4_t)               \
+  MEMBER(rx_filtered_no_expo, vec4_t)       \
   MEMBER(rx_override, vec4_t)               \
   MEMBER(stick_calibration_wizard, uint8)   \
   MEMBER(rx_rssi, float)                    \

--- a/src/main/input.c
+++ b/src/main/input.c
@@ -65,20 +65,24 @@ void input_stick_vector(float rx_input[], float maxangle) {
   // without this the quad will not invert if angle difference = 180
 }
 
-static float calc_bf_rates(int axis) {
 #define SETPOINT_RATE_LIMIT 1998.0f
 #define RC_RATE_INCREMENTAL 14.54f
 
+static float calc_bf_rates(int axis) {
   float rcRate, superExpo;
-  if (axis == ROLL) {
+  switch (axis) {
+  case ROLL:
     rcRate = profile.rate.betaflight.rc_rate.roll;
     superExpo = profile.rate.betaflight.super_rate.roll;
-  } else if (axis == PITCH) {
+    break;
+  case PITCH:
     rcRate = profile.rate.betaflight.rc_rate.pitch;
     superExpo = profile.rate.betaflight.super_rate.pitch;
-  } else {
+    break;
+  case YAW:
     rcRate = profile.rate.betaflight.rc_rate.yaw;
     superExpo = profile.rate.betaflight.super_rate.yaw;
+    break;
   }
   if (rcRate > 2.0f) {
     rcRate += RC_RATE_INCREMENTAL * (rcRate - 2.0f);
@@ -92,6 +96,72 @@ static float calc_bf_rates(int axis) {
   return constrainf(angleRate, -SETPOINT_RATE_LIMIT, SETPOINT_RATE_LIMIT) * (float)DEGTORAD;
 }
 
+static float calc_actual_rates(int axis) {
+  float centerSensitivity, maxRate;
+  switch (axis) {
+  case ROLL:
+    centerSensitivity = profile.rate.acutal.center_sensitivity.roll;
+    maxRate = profile.rate.acutal.max_rate.roll;
+    break;
+  case PITCH:
+    centerSensitivity = profile.rate.actual.center_sensitivity.pitch;
+    maxRate = profile.rate.acutal.max_rate.pitch;
+    break;
+  case YAW:
+    centerSensitivity = profile.rate.actual.center_sensitivity.yaw;
+    maxRate = profile.rate.actual.max_rate.yaw;
+    break;
+  }
+    float stickMovement = maxRate - centerSensitivity;
+    if (stickMovement < 0) {
+      stickMovement = 0;
+    }
+    return state.rx_filtered_no_expo.axis[axis] * centerSensitivity + stickMovement * state.rx_filtered.axis[axis];
+}
+
+static float calc_kiss_rates(int axis) {
+  float kissRates, rcRates;
+  switch (axis) {
+  case ROLL:
+    rcRates = profile.rate.kiss.rc_rate.roll;
+    kissRates = profile.rate.kiss.rate.roll;
+    break;
+  case PITCH:
+    rcRates = profile.rate.kiss.rc_rate.pitch;
+    kissRates = profile.rate.kiss.rate.pitch;
+    break;
+  case YAW:
+    rcRates = profile.rate.kiss.rc_rate.yaw;
+    kissRates = profile.rate.kiss.rate.yaw;
+    break;
+  }
+
+  kissRates = 1 / (constrainf(1 - (state.rx_filtered_no_expo.axis[axis] * kissRates), 0.01, 1.0));
+  rcRates = state.rx_filtered.axis[axis] * rcRates;
+  return constrainf(2000.0 * kissRates * rcRates, -SETPOINT_RATE_LIMIT, SETPOINT_RATE_LIMIT) * (float)DEGTORAD;
+}
+
+static float calc_raceflight_rates(int axis) {
+  float rate, acroPlus;
+  switch (axis) {
+  case ROLL:
+    rate = profile.rate.raceflight.rate.roll;
+    acroPlus = profile.rate.raceflight.acro_plus.roll;
+    break;
+  case PITCH:
+    rate = profile.rate.raceflight.rate.pitch;
+    acroPlus = profile.rate.raceflight.acro_plus.pitch;
+    break;
+  case YAW:
+    rate = profile.rate.raceflight.rate.yaw;
+    acroPlus = profile.rate.raceflight.acro_plus.yaw;
+  break;
+  }
+
+  float angleRate = state.rx_filtered.axis[axis] * rate;
+  return angleRate = angleRate * (1 + state.rx_filtered_no_expo.axis[axis] * acroPlus);
+}
+
 void input_rates_calc(float rates[]) {
   // high-low rates switch
   float rate_multiplier = 1.0;
@@ -99,13 +169,31 @@ void input_rates_calc(float rates[]) {
     rate_multiplier = profile.rate.low_rate_mulitplier;
   }
 
-  if (profile.rate.mode == RATE_MODE_BETAFLIGHT) {
+  switch (profile.rate.mode) {
+  case RATE_MODE_BETAFLIGHT:
     rates[0] = rate_multiplier * calc_bf_rates(0);
     rates[1] = rate_multiplier * calc_bf_rates(1);
     rates[2] = rate_multiplier * calc_bf_rates(2);
-  } else {
+    break;
+  case RATE_MODE_ACTUAL:
+    rates[0] = rate_multiplier * calc_actual_rates(0);
+    rates[1] = rate_multiplier * calc_actual_rates(1);
+    rates[2] = rate_multiplier * calc_actual_rates(2);
+    break;
+  case RATE_MODE_KISS:
+    rates[0] = rate_multiplier * calc_kiss_rates(0);
+    rates[1] = rate_multiplier * calc_kiss_rates(1);
+    rates[2] = rate_multiplier * calc_kiss_rates(2);
+    break;
+  case RATE_MODE_RACEFLIGHT:
+    rates[0] = rate_multiplier * calc_raceflight_rates(0);
+    rates[1] = rate_multiplier * calc_raceflight_rates(1);
+    rates[2] = rate_multiplier * calc_raceflight_rates(2);
+    break;
+  case RATE_MODE_SILVERWARE:
     rates[0] = rate_multiplier * state.rx_filtered.axis[0] * profile.rate.silverware.max_rate.roll * DEGTORAD;
     rates[1] = rate_multiplier * state.rx_filtered.axis[1] * profile.rate.silverware.max_rate.pitch * DEGTORAD;
     rates[2] = rate_multiplier * state.rx_filtered.axis[2] * profile.rate.silverware.max_rate.yaw * DEGTORAD;
+    break;
   }
 }


### PR DESCRIPTION
Add new rate curves and fix bf rates, probably broke some stuff, willing to fix it when I get some feedback. I think a discussion of what the angle rates should be should also be addressed. Only the silverware rates type has ability to mess with angle rates separately. Perhaps we should make the silverware angle expo always be the expo used while in angle mode and the other expo used for rates.